### PR TITLE
bugfix persistent session headers

### DIFF
--- a/pysnow/request.py
+++ b/pysnow/request.py
@@ -102,7 +102,7 @@ class SnowRequest(object):
         self._url = self._url_builder.get_appended_custom("/{0}".format(record['sys_id']))
         return self._get_response('DELETE').one()
 
-    def custom(self, method, path_append=None, headers=None, **kwargs):
+    def custom(self, method, path_append=None, **kwargs):
         """Creates a custom request
 
         :param method: HTTP method
@@ -119,4 +119,4 @@ class SnowRequest(object):
                 raise InvalidUsage("Argument 'path_append' must be a string in the following format: "
                                    "/path-to-append[/.../...]")
 
-        return self._get_response(method, headers=headers, **kwargs)
+        return self._get_response(method, **kwargs)

--- a/pysnow/request.py
+++ b/pysnow/request.py
@@ -112,10 +112,6 @@ class SnowRequest(object):
         :return:
             - :class:`pysnow.Response` object
         """
-
-        if headers:
-            self._session.headers.update(headers)
-
         if path_append is not None:
             try:
                 self._url = self._url_builder.get_appended_custom(path_append)
@@ -123,4 +119,4 @@ class SnowRequest(object):
                 raise InvalidUsage("Argument 'path_append' must be a string in the following format: "
                                    "/path-to-append[/.../...]")
 
-        return self._get_response(method, **kwargs)
+        return self._get_response(method, headers=headers, **kwargs)


### PR DESCRIPTION
Fixes https://github.com/rbw/pysnow/issues/117 where calls to pysnow's `custom` request method bleed headers between request causing unpredictable behavior. It's better to set request headers per-request than to set them at the request level. (At least for things like content-type)