### PR TITLE
Add gte and lte, and add criterion based query building.

### DIFF
--- a/pysnow/criterion.py
+++ b/pysnow/criterion.py
@@ -14,7 +14,7 @@ from .exceptions import (
 )
 
 
-class Term:
+class Term(object):
 
     @staticmethod
     def wrap_constant(value, types, list_type=False):
@@ -198,7 +198,7 @@ class Criterion(Term):
         raise NotImplementedError()
 
 
-class EmptyCriterion:
+class EmptyCriterion(object):
     def __and__(self, other):
         return other
 
@@ -449,7 +449,7 @@ class Field(Criterion):
         return self.name
 
 
-class Table:
+class Table(object):
     '''
         Allows the following:
 

--- a/pysnow/criterion.py
+++ b/pysnow/criterion.py
@@ -246,7 +246,7 @@ class IsEmptyCriterion(Criterion):
 
     def get_query(self, **kwargs):
         term = self.term.get_query(**kwargs)
-        return f'{term}ISEMPTY'
+        return '{}ISEMPTY'.format(term)
 
 
 class NotEmptyCriterion(Criterion):
@@ -256,7 +256,7 @@ class NotEmptyCriterion(Criterion):
 
     def get_query(self, **kwargs):
         term = self.term.get_query(**kwargs)
-        return f'{term}ISNOTEMPTY'
+        return '{}ISNOTEMPTY'.format(term)
 
 
 class IsAnythingCriterion(Criterion):
@@ -266,7 +266,7 @@ class IsAnythingCriterion(Criterion):
 
     def get_query(self, **kwargs):
         term = self.term.get_query(**kwargs)
-        return f'{term}ANYTHING'
+        return '{}ANYTHING'.format(term)
 
 
 class IsEmptyStringCriterion(Criterion):
@@ -276,7 +276,7 @@ class IsEmptyStringCriterion(Criterion):
 
     def get_query(self, **kwargs):
         term = self.term.get_query(**kwargs)
-        return f'{term}EMPTYSTRING'
+        return '{}EMPTYSTRING'.format(term)
 
 
 class BetweenCriterion(Criterion):
@@ -300,8 +300,8 @@ class BetweenCriterion(Criterion):
                 "Expected both `start` and `end` of type `int` "
                 "or instance of `datetime`, not %s and %s" % (type(start), type(end))
             )
-
-        return f'{term}BETWEEN{dt_between}'
+        
+        return '{}BETWEEN{}'.format(term, dt_between)
 
 
 class DateTimeOnCriterion(Criterion):
@@ -313,12 +313,16 @@ class DateTimeOnCriterion(Criterion):
     def get_query(self, **kwargs):
         term = self.term.get_query(**kwargs)
         if isinstance(self.criteria, DateTimeOn):
-            criteria = self.criteria.value
-            return f'{term}ON{criteria}'
+            return '{term}ON{criteria}'.format(
+                term=term,
+                criteria=self.criteria.value
+            )
         else:
-            start = self.criteria.get_query(date_only=True, extra_param='start')
-            end = self.criteria.get_query(date_only=True, extra_param='end')
-            return f'{term}ONcustom@{start}@{end}'
+            return '{term}ONcustom@{start}@{end}'.format(
+                term=term,
+                start=self.criteria.get_query(date_only=True, extra_param='start'),
+                end=self.criteria.get_query(date_only=True, extra_param='end')
+            )
 
 
 class DateTimeNotOnCriterion(Criterion):
@@ -330,12 +334,16 @@ class DateTimeNotOnCriterion(Criterion):
     def get_query(self, **kwargs):
         term = self.term.get_query(**kwargs)
         if isinstance(self.criteria, DateTimeOn):
-            criteria = self.criteria.value
-            return f'{term}NOTON{criteria}'
+            return '{term}NOTON{criteria}'.format(
+                term=term,
+                criteria=self.criteria.value
+            )
         else:
-            start = self.criteria.get_query(date_only=True, extra_param='start')
-            end = self.criteria.get_query(date_only=True, extra_param='end')
-            return f'{term}NOTONcustom@{start}@{end}'
+            return '{term}NOTONcustom@{start}@{end}'.format(
+                term=term,
+                start=self.criteria.get_query(date_only=True, extra_param='start'),
+                end=self.criteria.get_query(date_only=True, extra_param='end')
+            )
 
 
 class OrderCriterion(Criterion):
@@ -347,9 +355,9 @@ class OrderCriterion(Criterion):
     def get_query(self, **kwargs):
         term = self.term.get_query(**kwargs)
         if self.direction == Order.asc or (isinstance(self.direction, six.string_types) and self.direction.lower() == 'asc'):
-            return f'ORDERBY{term}'
+            return 'ORDERBY{term}'.format(term=term)
         elif self.direction == Order.desc or (isinstance(self.direction, six.string_types) and self.direction.lower() == 'desc'):
-            return f'ORDERBYDESC{term}'
+            return 'ORDERBYDESC{term}'.format(term=term)
         else:
             raise QueryTypeError(
                 "Expected 'asc', 'desc', or an instance of Order, not %s"
@@ -406,9 +414,9 @@ class DateTimeValueWrapper(ValueWrapper):
                 value = datetime_.strftime("%Y-%m-%d %H:%M:%S")
 
             if extra_param:
-                value += f'", "{extra_param}'
+                value += '", "{}'.format(extra_param)
 
-            return f'javascript:gs.dateGenerate("{value}")'
+            return 'javascript:gs.dateGenerate("{}")'.format(value)
         else:
             raise QueryTypeError(
                 "Expected value to be an instance of `datetime`, not %s"

--- a/pysnow/criterion.py
+++ b/pysnow/criterion.py
@@ -1,0 +1,450 @@
+import inspect
+import six
+import pytz
+from datetime import datetime
+
+from .enums import (
+    Boolean,
+    Equality,
+    DateTimeOn,
+)
+from .exceptions import (
+    QueryTypeError,
+)
+
+
+class Term:
+
+    @staticmethod
+    def wrap_constant(value, types, list_type=False):
+        if list_type:
+            if isinstance(value, (list, tuple)):
+                if all(type(x) in types for x in value):
+                    return ListValueWrapper(value, types)
+                else:
+                    caller = inspect.currentframe().f_back.f_code.co_name
+                    raise QueryTypeError(
+                        "Expected value to be a list of type %s, not %s"
+                        % (types, type(value))
+                    )
+            else:
+                caller = inspect.currentframe().f_back.f_code.co_name
+                raise QueryTypeError(
+                    "Invalid type passed to %s() , expected list or tuple" % (caller)
+                )
+        elif isinstance(value, ValueWrapper) and (value.type_ in types or (value.type_ == list and list_type)):
+            return value
+        # allow other types than datetime, as long as they have strftime
+        elif hasattr(value, "strftime") and datetime in types:
+            return DateTimeValueWrapper(value)
+        elif not type(value) in types:
+            caller = inspect.currentframe().f_back.f_code.co_name
+            raise QueryTypeError(
+                "Invalid type passed to %s() , expected: %s" % (caller, types)
+            )
+        elif isinstance(value, int):
+            return IntValueWrapper(value)
+        elif isinstance(value, str):
+            return StringValueWrapper(value)
+        else:
+            return value
+
+    def eq(self, other):
+        return self == other
+
+    def gt(self, other):
+        return self > other
+
+    def gte(self, other):
+        return self >= other
+
+    def lt(self, other):
+        return self < other
+
+    def lte(self, other):
+        return self <= other
+
+    def ne(self, other):
+        return self != other
+
+    def is_empty(self):
+        return IsEmptyCriterion(self)
+
+    def is_not_empty(self):
+        return NotEmptyCriterion(self)
+
+    def is_empty_string(self):
+        return IsEmptyStringCriterion(self)
+
+    def between(self, lower, upper):
+        return BetweenCriterion(
+            self,
+            self.wrap_constant(lower, types=[int, datetime]),
+            self.wrap_constant(upper, types=[int, datetime])
+        )
+
+    def starts_with(self, other):
+        return BasicCriterion('STARTSWITH', self, self.wrap_constant(other, types=[str]))
+
+    def ends_with(self, other):
+        return BasicCriterion('ENDSWITH', self, self.wrap_constant(other, types=[str]))
+
+    def contains(self, other):
+        return self.like(other)
+
+    def not_contains(self, other):
+        return self.not_like(other)
+
+    def like(self, other):
+        return BasicCriterion('LIKE', self, self.wrap_constant(other, types=[str]))
+
+    def not_like(self, other):
+        return BasicCriterion('NOT LIKE', self, self.wrap_constant(other, types=[str]))
+
+    def is_in(self, other):
+        return BasicCriterion('IN', self, self.wrap_constant(other, types=[int, str], list_type=True))
+
+    def not_in(self, other):
+        return BasicCriterion('NOT IN', self, self.wrap_constant(other, types=[int, str], list_type=True))
+
+    def is_anything(self, other):
+        return IsAnythingCriterion(self)
+
+    def is_same(self, other):
+        return BasicCriterion('SAMEAS', self, self.wrap_constant(other, types=[Field]))
+
+    def is_different(self, other):
+        return BasicCriterion('NSAMEAS', self, self.wrap_constant(other, types=[Field]))
+
+    def __eq__(self, other):
+        return BasicCriterion(Equality.eq, self, self.wrap_constant(other, types=[int, str]))
+
+    def __ne__(self, other):
+        return BasicCriterion(Equality.ne, self, self.wrap_constant(other, types=[int, str]))
+
+    def __gt__(self, other):
+        return BasicCriterion(Equality.gt, self, self.wrap_constant(other, types=[int, datetime]))
+
+    def __ge__(self, other):
+        return BasicCriterion(Equality.gte, self, self.wrap_constant(other, types=[int, datetime]))
+
+    def __lt__(self, other):
+        return BasicCriterion(Equality.lt, self, self.wrap_constant(other, types=[int, datetime]))
+
+    def __le__(self, other):
+        return BasicCriterion(Equality.lte, self, self.wrap_constant(other, types=[int, datetime]))
+
+    # DateTime only 
+    def on(self, other):
+        return DateTimeOnCriterion(self, self.wrap_constant(other, types=[datetime, DateTimeOn]))
+
+    def not_on(self, other):
+        return DateTimeNotOnCriterion(self, self.wrap_constant(other, types=[datetime, DateTimeOn]))
+
+    # End DateTime only
+
+    def __str__(self):
+        return self.get_query()
+
+    def get_query(self, **kwargs):
+        raise NotImplementedError()
+
+
+class Criterion(Term):
+
+    def AND(self, other):
+        return self & other
+
+    def OR(self, other):
+        return self | other
+
+    def NQ(self, other):
+        return self ^ other
+
+    def __and__(self, other):
+        return BasicCriterion(Boolean.and_, self, other)
+
+    def __or__(self, other):
+        return BasicCriterion(Boolean.or_, self, other)
+
+    def __xor__(self, other):
+        '''
+            While not really an XOR operation, this allows us to use Python's bitwise operators
+        '''
+        return BasicCriterion(Boolean.nq_, self, other)
+
+    @staticmethod
+    def any(terms=()):
+        crit = EmptyCriterion()
+
+        for term in terms:
+            crit |= term
+
+        return crit
+
+    @staticmethod
+    def all(terms=()):
+        crit = EmptyCriterion()
+
+        for term in terms:
+            crit &= term
+
+        return crit
+
+    def get_query(self, **kwargs):
+        raise NotImplementedError()
+
+
+class EmptyCriterion:
+    def __and__(self, other):
+        return other
+
+    def __or__(self, other):
+        return other
+
+    def __xor__(self, other):
+        return other
+
+
+class BasicCriterion(Criterion):
+    def __init__(self, comparator, left, right):
+        """
+        A wrapper for a basic criterion such as equality or inequality.
+        This wraps three parts, a left and right term and a comparator which
+        defines the type of comparison.
+
+
+        :param comparator:
+            Type: Comparator
+            This defines the type of comparison, such as {quote}={quote} or
+            {quote}>{quote}.
+        :param left:
+            The term on the left side of the expression.
+        :param right:
+            The term on the right side of the expression.
+        """
+        super(BasicCriterion, self).__init__()
+        self.comparator = comparator
+        self.left = left
+        self.right = right
+
+    def get_query(self, **kwargs):
+        return '{left}{comparator}{right}'.format(
+            comparator=getattr(self.comparator, 'value', self.comparator),
+            left=self.left.get_query(**kwargs),
+            right=self.right.get_query(**kwargs),
+        )
+
+
+class IsEmptyCriterion(Criterion):
+    def __init__(self, term):
+        super(IsEmptyCriterion, self).__init__()
+        self.term = term
+
+    def get_query(self, **kwargs):
+        term = self.term.get_query(**kwargs)
+        return f'{term}ISEMPTY'
+
+
+class NotEmptyCriterion(Criterion):
+    def __init__(self, term):
+        super(NotEmptyCriterion, self).__init__()
+        self.term = term
+
+    def get_query(self, **kwargs):
+        term = self.term.get_query(**kwargs)
+        return f'{term}ISNOTEMPTY'
+
+
+class IsAnythingCriterion(Criterion):
+    def __init__(self, term):
+        super(IsAnythingCriterion, self).__init__()
+        self.term = term
+
+    def get_query(self, **kwargs):
+        term = self.term.get_query(**kwargs)
+        return f'{term}ANYTHING'
+
+
+class IsEmptyStringCriterion(Criterion):
+    def __init__(self, term):
+        super(IsEmptyStringCriterion, self).__init__()
+        self.term = term
+
+    def get_query(self, **kwargs):
+        term = self.term.get_query(**kwargs)
+        return f'{term}EMPTYSTRING'
+
+
+class BetweenCriterion(Criterion):
+    def __init__(self, term, start, end):
+        super(BetweenCriterion, self).__init__()
+        self.term = term
+        self.start = start
+        self.end = end
+
+    def get_query(self, **kwargs):
+        term = self.term.get_query(**kwargs)
+        start = self.start.get_query(**kwargs)
+        end = self.end.get_query(**kwargs)
+
+        if (
+            isinstance(self.start, DateTimeValueWrapper) and isinstance(self.end, DateTimeValueWrapper)
+            or (isinstance(self.start, IntValueWrapper) and isinstance(self.end, IntValueWrapper))
+        ):
+            dt_between = "%d@%d" % (start, end)
+        else:
+            raise QueryTypeError(
+                "Expected both `start` and `end` of type `int` "
+                "or instance of `datetime`, not %s and %s" % (type(start), type(end))
+            )
+
+        return f'{term}BETWEEN{dt_between}'
+
+
+class DateTimeOnCriterion(Criterion):
+    def __init__(self, term, criteria):
+        super(DateTimeOnCriterion, self).__init__()
+        self.term = term
+        self.criteria = criteria
+
+    def get_query(self, **kwargs):
+        term = self.term.get_query(**kwargs)
+        if isinstance(self.criteria, DateTimeOn):
+            criteria = self.criteria.value
+            return f'{term}ON{criteria}'
+        else:
+            start = self.criteria.get_query(date_only=True, extra_param='start')
+            end = self.criteria.get_query(date_only=True, extra_param='end')
+            return f'{term}ONcustom@{start}@{end}'
+
+
+class DateTimeNotOnCriterion(Criterion):
+    def __init__(self, term, criteria):
+        super(DateTimeNotOnCriterion, self).__init__()
+        self.term = term
+        self.criteria = criteria
+
+    def get_query(self, **kwargs):
+        term = self.term.get_query(**kwargs)
+        if isinstance(self.criteria, DateTimeOn):
+            criteria = self.criteria.value
+            return f'{term}NOTON{criteria}'
+        else:
+            start = self.criteria.get_query(date_only=True, extra_param='start')
+            end = self.criteria.get_query(date_only=True, extra_param='end')
+            return f'{term}NOTONcustom@{start}@{end}'
+
+
+class ValueWrapper(Term):
+    def __init__(self, type_):
+        self.type_ = type_
+
+
+class IntValueWrapper(ValueWrapper):
+    def __init__(self, value):
+        super(IntValueWrapper, self).__init__(int)
+        self.value = value
+
+    def get_query(self, **kwargs):
+        if isinstance(self.value, int):
+            return self.value
+        else:
+            raise QueryTypeError(
+                "Expected value to be an instance of `int`, not %s"
+                % type(self.value)
+            )
+
+
+class StringValueWrapper(ValueWrapper):
+    def __init__(self, value):
+        super(StringValueWrapper, self).__init__(str)
+        self.value = value
+
+    def get_query(self, **kwargs):
+        if isinstance(self.value, six.string_types):
+            return self.value
+        else:
+            raise QueryTypeError(
+                "Expected value to be an instance of `str`, not %s"
+                % type(self.value)
+            )
+
+
+class DateTimeValueWrapper(ValueWrapper):
+    def __init__(self, value):
+        super(DateTimeValueWrapper, self).__init__(datetime)
+        self.value = value
+
+    def get_query(self, date_only=False, extra_param=None, **kwargs):
+        if hasattr(self.value, "strftime"):
+            datetime_ = datetime_as_utc(self.value)
+            if date_only:
+                value = datetime_.strftime("%Y-%m-%d")
+            else:
+                value = datetime_.strftime("%Y-%m-%d %H:%M:%S")
+
+            if extra_param:
+                value += f'", "{extra_param}'
+
+            return f'javascript:gs.dateGenerate("{value}")'
+        else:
+            raise QueryTypeError(
+                "Expected value to be an instance of `datetime`, not %s"
+                % type(self.value)
+            )
+
+
+class ListValueWrapper(ValueWrapper):
+    def __init__(self, value, types):
+        super(ListValueWrapper, self).__init__(list)
+        self.value = value
+        self.types = types
+
+    def get_query(self, **kwargs):
+        if isinstance(self.value, (list, tuple)) and all(type(x) in self.types for x in self.value):
+            return ",".join(map(str, self.value))
+        else:
+            raise QueryTypeError(
+                "Expected value to be a list of type %s, not %s"
+                % (self.types, type(self.value))
+            )
+
+
+class Field(Criterion):
+    def __init__(self, name):
+        super(Field, self).__init__()
+        self.name = name
+
+    def get_query(self, **kwargs):
+        return self.name
+
+
+class Table:
+    '''
+        Allows the following:
+
+        ```
+        incident = Table(incident)
+        criterion = incident.company.eq('3dasd3')
+        ```
+    '''
+
+    # Could be used to automate resource creation?
+    def __init__(self, name):
+        self.table_name = name
+
+    def field(self, name):
+        return Field(name)
+
+    def __getattr__(self, name):
+        return self.field(name)
+
+    def __getitem__(self, name):
+        return self.field(name)
+
+
+def datetime_as_utc(date_obj):
+    if date_obj.tzinfo is not None and date_obj.tzinfo.utcoffset(date_obj) is not None:
+        return date_obj.astimezone(pytz.UTC)
+    return date_obj

--- a/pysnow/enums.py
+++ b/pysnow/enums.py
@@ -1,0 +1,84 @@
+
+from enum import Enum
+
+
+class Comparator(Enum):
+    pass
+
+
+class Equality(Comparator):
+    eq = '='
+    ne = '!='
+    gt = '>'
+    gte = '>='
+    lt = '<'
+    lte = '<='
+
+
+class Boolean(Comparator):
+    and_ = '^'
+    or_ = '^OR'
+    nq_ = '^NQ'
+
+
+# Retrieved by inspecting the `ON` dropdown
+class DateTimeOn(Enum):
+    today = 'Today@javascript:gs.beginningOfToday()@javascript:gs.endOfToday()'
+    yesterday = 'Yesterday@javascript:gs.beginningOfYesterday()@javascript:gs.endOfYesterday()'
+    tomorrow = 'Tomorrow@javascript:gs.beginningOfTomorrow()@javascript:gs.endOfTomorrow()'
+    this_week = 'This week@javascript:gs.beginningOfThisWeek()@javascript:gs.endOfThisWeek()'
+    last_week = 'Last week@javascript:gs.beginningOfLastWeek()@javascript:gs.endOfLastWeek()'
+    next_week = 'Next week@javascript:gs.beginningOfNextWeek()@javascript:gs.endOfNextWeek()'
+    this_month = 'This month@javascript:gs.beginningOfThisMonth()@javascript:gs.endOfThisMonth()'
+    last_month = 'Last month@javascript:gs.beginningOfLastMonth()@javascript:gs.endOfLastMonth()'
+    next_month = 'Next month@javascript:gs.beginningOfNextMonth()@javascript:gs.endOfNextMonth()'
+    last_3_months = 'Last 3 months@javascript:gs.beginningOfLast3Months()@javascript:gs.endOfLast3Months()'
+    last_6_months = 'Last 6 months@javascript:gs.beginningOfLast6Months()@javascript:gs.endOfLast6Months()'
+    last_9_months = 'Last 9 months@javascript:gs.beginningOfLast9Months()@javascript:gs.endOfLast9Months()'
+    last_12_months = 'Last 12 months@javascript:gs.beginningOfLast12Months()@javascript:gs.endOfLast12Months()'
+    this_quarter = 'This quarter@javascript:gs.beginningOfThisQuarter()@javascript:gs.endOfThisQuarter()'
+    last_quarter = 'Last quarter@javascript:gs.beginningOfLastQuarter()@javascript:gs.endOfLastQuarter()'
+    last_2_quarters = 'Last 2 quarters@javascript:gs.beginningOfLast2Quarters()@javascript:gs.endOfLast2Quarters()'
+    next_quarter = 'Next quarter@javascript:gs.beginningOfNextQuarter()@javascript:gs.endOfNextQuarter()'
+    next_2_quarter = 'Next 2 quarters@javascript:gs.beginningOfNext2Quarters()@javascript:gs.endOfNext2Quarters()'
+    this_year = 'This year@javascript:gs.beginningOfThisYear()@javascript:gs.endOfThisYear()'
+    next_year = 'Next year@javascript:gs.beginningOfNextYear()@javascript:gs.endOfNextYear()'
+    last_yesr = 'Last year@javascript:gs.beginningOfLastYear()@javascript:gs.endOfLastYear()'
+    last_2_years = 'Last 2 years@javascript:gs.beginningOfLast2Years()@javascript:gs.endOfLast2Years()'
+    last_7_days = 'Last 7 days@javascript:gs.beginningOfLast7Days()@javascript:gs.endOfLast7Days()'
+    last_30_days = 'Last 30 days@javascript:gs.beginningOfLast30Days()@javascript:gs.endOfLast30Days()'
+    last_60_days = 'Last 60 days@javascript:gs.beginningOfLast60Days()@javascript:gs.endOfLast60Days()'
+    last_90_days = 'Last 90 days@javascript:gs.beginningOfLast90Days()@javascript:gs.endOfLast90Days()'
+    last_120_days = 'Last 120 days@javascript:gs.beginningOfLast120Days()@javascript:gs.endOfLast120Days()'
+    this_hour = 'Current hour@javascript:gs.beginningOfCurrentHour()@javascript:gs.endOfCurrentHour()'
+    last_hour = 'Last hour@javascript:gs.beginningOfLastHour()@javascript:gs.endOfLastHour()'
+    last_2_hours = 'Last 2 hours@javascript:gs.beginningOfLast2Hours()@javascript:gs.endOfLast2Hours()'
+    this_minute = 'Current minute@javascript:gs.beginningOfCurrentMinute()@javascript:gs.endOfCurrentMinute()'
+    last_minute = 'Last minute@javascript:gs.beginningOfLastMinute()@javascript:gs.endOfLastMinute()'
+    last_15_minutes = 'Last 15 minutes@javascript:gs.beginningOfLast15Minutes()@javascript:gs.endOfLast15Minutes()'
+    last_30_minutes = 'Last 30 minutes@javascript:gs.beginningOfLast30Minutes()@javascript:gs.endOfLast30Minutes()'
+    last_45_minutes = 'Last 45 minutes@javascript:gs.beginningOfLast45Minutes()@javascript:gs.endOfLast45Minutes()'
+    one_year_ago = 'One year ago@javascript:gs.beginningOfOneYearAgo()@javascript:gs.endOfOneYearAgo()'
+
+
+class RelativeEquality(Comparator):
+    ee = 'EE'
+    eq = 'EE'  # on
+    gt = 'GT'  # after
+    gte = 'GE'  # on or after
+    lt = 'LT'  # before
+    lte = 'LTE'  # on or before
+
+
+class RelativeTimeWindows(Enum):
+    minutes = 'minute'
+    hours = 'hour'
+    days = 'dayofweek'
+    months = 'month'
+    quarters = 'quarter'
+    years = 'year'
+
+
+class RelativeDirection(Enum):
+    ago = 'ago'
+    ahead = 'ahead'

--- a/pysnow/enums.py
+++ b/pysnow/enums.py
@@ -2,6 +2,11 @@
 from enum import Enum
 
 
+class Order(Enum):
+    asc = 'ASC'
+    desc = 'DESC'
+
+
 class Comparator(Enum):
     pass
 

--- a/pysnow/params_builder.py
+++ b/pysnow/params_builder.py
@@ -2,6 +2,7 @@
 
 import six
 
+from .criterion import Criterion
 from .query_builder import QueryBuilder
 
 from .exceptions import InvalidUsage
@@ -32,7 +33,7 @@ class ParamsBuilder(object):
             - ServiceNow-compatible string-type query
         """
 
-        if isinstance(query, QueryBuilder):
+        if isinstance(query, QueryBuilder) or isinstance(query, Criterion):
             # Get string-representation of the passed :class:`pysnow.QueryBuilder` object
             return str(query)
         elif isinstance(query, dict):
@@ -43,7 +44,7 @@ class ParamsBuilder(object):
             return query
         else:
             raise InvalidUsage(
-                "Query must be of type string, dict or a QueryBuilder object"
+                "Query must be of type string, dict, QueryBuilder, or Criterion"
             )
 
     def add_custom(self, params):

--- a/pysnow/query_builder.py
+++ b/pysnow/query_builder.py
@@ -139,6 +139,24 @@ class QueryBuilder(object):
 
         return self._add_condition(">", greater_than, types=[int, str])
 
+    def greater_than_or_equal(self, greater_than):
+        """Adds new `>=` condition
+
+        :param greater_than: str or datetime compatible object (naive UTC datetime or tz-aware datetime)
+        :raise:
+            - QueryTypeError: if `greater_than` is of an unexpected type
+        """
+
+        if hasattr(greater_than, "strftime"):
+            greater_than = datetime_as_utc(greater_than).strftime("%Y-%m-%d %H:%M:%S")
+        elif isinstance(greater_than, six.string_types):
+            raise QueryTypeError(
+                "Expected value of type `int` or instance of `datetime`, not %s"
+                % type(greater_than)
+            )
+
+        return self._add_condition(">=", greater_than, types=[int, str])
+
     def less_than(self, less_than):
         """Adds new `<` condition
 
@@ -156,6 +174,24 @@ class QueryBuilder(object):
             )
 
         return self._add_condition("<", less_than, types=[int, str])
+
+    def less_than_or_equal(self, less_than):
+        """Adds new `<=` condition
+
+        :param less_than: str or datetime compatible object (naive UTC datetime or tz-aware datetime)
+        :raise:
+            - QueryTypeError: if `less_than` is of an unexpected type
+        """
+
+        if hasattr(less_than, "strftime"):
+            less_than = datetime_as_utc(less_than).strftime("%Y-%m-%d %H:%M:%S")
+        elif isinstance(less_than, six.string_types):
+            raise QueryTypeError(
+                "Expected value of type `int` or instance of `datetime`, not %s"
+                % type(less_than)
+            )
+
+        return self._add_condition("<=", less_than, types=[int, str])
 
     def between(self, start, end):
         """Adds new `BETWEEN` condition

--- a/pysnow/request.py
+++ b/pysnow/request.py
@@ -78,6 +78,12 @@ class SnowRequest(object):
         self._parameters.limit = kwargs.pop("limit", 10000)
         self._parameters.offset = kwargs.pop("offset", 0)
         self._parameters.fields = kwargs.pop("fields", kwargs.pop("fields", []))
+        if "display_value" in kwargs:
+            self._parameters.display_value = kwargs.pop("display_value")
+        if "exclude_reference_link" in kwargs:
+            self._parameters.exclude_reference_link = kwargs.pop("exclude_reference_link")
+        if "suppress_pagination_header" in kwargs:
+            self._parameters.suppress_pagination_header = kwargs.pop("suppress_pagination_header")
 
         return self._get_response("GET", stream=kwargs.pop("stream", False))
 

--- a/tests/test_criterion.py
+++ b/tests/test_criterion.py
@@ -1,25 +1,21 @@
 # -*- coding: utf-8 -*-
 import unittest
 import pytz
-import pysnow
 from datetime import datetime as dt
 
 from pysnow.criterion import (
     Field,
 )
-from pysnow.enums import(
+from pysnow.enums import (
     DateTimeOn,
+    Order,
 )
 from pysnow.exceptions import (
-    QueryEmpty,
-    QueryExpressionError,
-    QueryMissingField,
-    QueryMultipleExpressions,
     QueryTypeError,
 )
 
 
-class TestQueryBuilder(unittest.TestCase):
+class TestCriterion(unittest.TestCase):
 
     def test_query_logical_and(self):
         # Make sure AND() operator between expressions works
@@ -299,6 +295,24 @@ class TestQueryBuilder(unittest.TestCase):
 
         q3 = Field("test").not_on(DateTimeOn.today)
         self.assertEqual(str(q3), 'testNOTONToday@javascript:gs.beginningOfToday()@javascript:gs.endOfToday()')
+
+    def test_query_order_desc(self):
+        # :meth:`order_descending` should generate ORDERBYDESC<field>
+        q = (
+            Field("foo").eq("bar")
+            &
+            Field("foo2").order(Order.desc)
+        )
+        self.assertEqual(str(q), "foo=bar^ORDERBYDESCfoo2")
+
+    def test_query_order_ascending(self):
+        # :meth:`order_descending` should generate ORDERBY<field>
+        q = (
+            Field("foo").eq("bar")
+            &
+            Field("foo2").order(Order.asc)
+        )
+        self.assertEqual(str(q), "foo=bar^ORDERBYfoo2")
 
     def test_complex_query(self):
         start = dt(2016, 2, 1)

--- a/tests/test_criterion.py
+++ b/tests/test_criterion.py
@@ -1,0 +1,339 @@
+# -*- coding: utf-8 -*-
+import unittest
+import pytz
+import pysnow
+from datetime import datetime as dt
+
+from pysnow.criterion import (
+    Field,
+)
+from pysnow.enums import(
+    DateTimeOn,
+)
+from pysnow.exceptions import (
+    QueryEmpty,
+    QueryExpressionError,
+    QueryMissingField,
+    QueryMultipleExpressions,
+    QueryTypeError,
+)
+
+
+class TestQueryBuilder(unittest.TestCase):
+
+    def test_query_logical_and(self):
+        # Make sure AND() operator between expressions works
+        q = (
+            Field("test").eq("test")
+            .AND(
+                Field("test2").eq("test")
+            )
+        )
+        self.assertEqual(str(q), "test=test^test2=test")
+
+    def test_query_logical_bitwise_and(self):
+        # Make sure AND() operator between expressions works
+        q = (
+            (Field("test") == "test")
+            &
+            (Field("test2") == "test")
+        )
+        self.assertEqual(str(q), "test=test^test2=test")
+
+    def test_query_logical_or(self):
+        # Make sure AND() operator between expressions works
+        q = (
+            Field("test").eq("test")
+            .OR(
+                Field("test2").eq("test")
+            )
+        )
+        self.assertEqual(str(q), "test=test^ORtest2=test")
+
+    def test_query_logical_bitwise_or(self):
+        # Make sure AND() operator between expressions works
+        q = (
+            (Field("test") == "test")
+            |
+            (Field("test2") == "test")
+        )
+        self.assertEqual(str(q), "test=test^ORtest2=test")
+
+    def test_query_logical_nq(self):
+        # Make sure AND() operator between expressions works
+        q = (
+            Field("test").eq("test")
+            .NQ(
+                Field("test2").eq("test")
+            )
+        )
+        self.assertEqual(str(q), "test=test^NQtest2=test")
+
+    def test_query_logical_bitwise_nq(self):
+        # Make sure AND() operator between expressions works
+        q = (
+            Field("test").eq("test")
+            ^
+            Field("test2").eq("test")
+        )
+        self.assertEqual(str(q), "test=test^NQtest2=test")
+
+    def test_query_cond_between(self):
+        # Make sure between with str arguments fails
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.between, "start", "end")
+
+        # Make sure between with int arguments works
+        q2 = Field("test").between(1, 2)
+        self.assertEqual(str(q2), "testBETWEEN1@2")
+
+        # Make sure between with dates works
+        start = dt(1970, 1, 1)
+        end = dt(1970, 1, 2)
+
+        q2 = Field("test").between(start, end)
+        self.assertEqual(
+            str(q2),
+            'testBETWEENjavascript:gs.dateGenerate("1970-01-01 00:00:00")'
+            '@javascript:gs.dateGenerate("1970-01-02 00:00:00")',
+        )
+
+    def test_query_cond_starts_with(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.starts_with, 1)
+
+        # Make sure a valid operation works
+        q2 = Field("test").starts_with("val")
+        self.assertEqual(str(q2), "testSTARTSWITHval")
+
+    def test_query_cond_ends_with(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.ends_with, 1)
+
+        # Make sure a valid operation works
+        q2 = Field("test").ends_with("val")
+        self.assertEqual(str(q2), "testENDSWITHval")
+
+    def test_query_cond_contains(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.contains, 1)
+
+        # Make sure a valid operation works
+        q2 = Field("test").contains("val")
+        self.assertEqual(str(q2), "testLIKEval")
+
+    def test_query_cond_not_contains(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.not_contains, 1)
+
+        # Make sure a valid operation works
+        q2 = Field("test").not_contains("val")
+        self.assertEqual(str(q2), "testNOT LIKEval")
+
+    def test_query_cond_is_empty(self):
+        # Make sure a valid operation works
+        q = Field("test").is_empty()
+
+        self.assertEqual(str(q), "testISEMPTY")
+
+    def test_query_cond_is_not_empty(self):
+        # Make sure a valid operation works
+        q = Field("test").is_not_empty()
+
+        self.assertEqual(str(q), "testISNOTEMPTY")
+
+    def test_query_cond_is_in(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.is_in, [dt])
+        self.assertRaises(QueryTypeError, q1.is_in, "single")
+
+        # Make sure a valid operation works (string list)
+        q3 = Field("test").is_in(["foo", "bar"])
+        self.assertEqual(str(q3), "testINfoo,bar")
+
+        # Make sure a valid operation works (int list)
+        q3 = Field("test").is_in([1, 2])
+        self.assertEqual(str(q3), "testIN1,2")
+
+    def test_query_cond_not_in(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.not_in, [dt])
+        self.assertRaises(QueryTypeError, q1.not_in, "single")
+
+        # Make sure a valid operation works (string list)
+        q3 = Field("test").not_in(["foo", "bar"])
+        self.assertEqual(str(q3), "testNOT INfoo,bar")
+
+        # Make sure a valid operation works (int list)
+        q3 = Field("test").not_in([1, 2])
+        self.assertEqual(str(q3), "testNOT IN1,2")
+
+    def test_query_cond_equals(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.eq, dt)
+
+        # Make sure a valid operation works (str)
+        q2 = Field("test").eq("test")
+        self.assertEqual(str(q2), "test=test")
+
+    def test_query_cond_not_equals(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.ne, dt)
+
+        # Make sure a valid operation works (str)
+        q2 = Field("test").ne("test")
+        self.assertEqual(str(q2), "test!=test")
+
+    def test_query_cond_greater_than(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.gt, "a")
+
+        # Make sure a valid operation works
+        q2 = Field("test").gt(1)
+        self.assertEqual(str(q2), "test>1")
+
+        # Make sure naive dates are assumed as UTC
+        q3 = Field("test").gt(dt(2016, 2, 1))
+        self.assertEqual(str(q3), 'test>javascript:gs.dateGenerate("2016-02-01 00:00:00")')
+
+        # Make sure tz-aware dates are converted to UTC (UTC+1)
+        q4 = (
+            Field("test")
+            .gt(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
+        )
+        self.assertEqual(str(q4), 'test>javascript:gs.dateGenerate("2016-02-01 02:00:00")')
+
+    def test_query_cond_less_than(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.lt, "a")
+
+        # Make sure a valid operation works
+        q2 = Field("test").lt(1)
+        self.assertEqual(str(q2), "test<1")
+
+        # Make sure naive dates are assumed as UTC
+        q3 = Field("test").lt(dt(2016, 2, 1))
+        self.assertEqual(str(q3), 'test<javascript:gs.dateGenerate("2016-02-01 00:00:00")')
+
+        # Make sure tz-aware dates are converted to UTC (UTC+1)
+        q3 = (
+            Field("test")
+            .lt(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
+        )
+        self.assertEqual(str(q3), 'test<javascript:gs.dateGenerate("2016-02-01 02:00:00")')
+
+    def test_query_cond_greater_than_or_equal(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.gte, "a")
+
+        # Make sure a valid operation works
+        q2 = Field("test").gte(1)
+        self.assertEqual(str(q2), "test>=1")
+
+        # Make sure naive dates are assumed as UTC
+        q3 = Field("test").gte(dt(2016, 2, 1))
+        self.assertEqual(str(q3), 'test>=javascript:gs.dateGenerate("2016-02-01 00:00:00")')
+
+        # Make sure tz-aware dates are converted to UTC (UTC+1)
+        q4 = (
+            Field("test")
+            .gte(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
+        )
+        self.assertEqual(str(q4), 'test>=javascript:gs.dateGenerate("2016-02-01 02:00:00")')
+
+    def test_query_cond_less_than_or_equal(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.lte, "a")
+
+        # Make sure a valid operation works
+        q2 = Field("test").lte(1)
+        self.assertEqual(str(q2), "test<=1")
+
+        # Make sure naive dates are assumed as UTC
+        q3 = Field("test").lte(dt(2016, 2, 1))
+        self.assertEqual(str(q3), 'test<=javascript:gs.dateGenerate("2016-02-01 00:00:00")')
+
+        # Make sure tz-aware dates are converted to UTC (UTC+1)
+        q3 = (
+            Field("test")
+            .lte(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
+        )
+        self.assertEqual(str(q3), 'test<=javascript:gs.dateGenerate("2016-02-01 02:00:00")')
+
+    def test_query_cond_on(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.on, "a")
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.on, 1)
+
+        # Make sure naive dates are assumed as UTC
+        q2 = Field("test").on(dt(2016, 2, 1))
+        self.assertEqual(str(q2), 'testONcustom@javascript:gs.dateGenerate("2016-02-01", "start")@javascript:gs.dateGenerate("2016-02-01", "end")')
+
+        q3 = Field("test").on(DateTimeOn.today)
+        self.assertEqual(str(q3), 'testONToday@javascript:gs.beginningOfToday()@javascript:gs.endOfToday()')
+
+    def test_query_cond_not_on(self):
+        # Make sure type checking works
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.not_on, "a")
+        q1 = Field("test")
+        self.assertRaises(QueryTypeError, q1.not_on, 1)
+
+        # Make sure naive dates are assumed as UTC
+        q2 = Field("test").not_on(dt(2016, 2, 1))
+        self.assertEqual(str(q2), 'testNOTONcustom@javascript:gs.dateGenerate("2016-02-01", "start")@javascript:gs.dateGenerate("2016-02-01", "end")')
+
+        q3 = Field("test").not_on(DateTimeOn.today)
+        self.assertEqual(str(q3), 'testNOTONToday@javascript:gs.beginningOfToday()@javascript:gs.endOfToday()')
+
+    def test_complex_query(self):
+        start = dt(2016, 2, 1)
+        end = dt(2016, 2, 10)
+
+        q = (
+            Field("f1").eq("val1")
+            .AND(
+                Field("f2").between(start, end)
+            )
+            .NQ(
+                Field("f3").eq("val3")
+            )
+        )
+
+        self.assertEqual(
+            str(q),
+            'f1=val1^f2BETWEENjavascript:gs.dateGenerate("2016-02-01 00:00:00")'
+            '@javascript:gs.dateGenerate("2016-02-10 00:00:00")^NQf3=val3',
+        )
+
+    def test_complex_query_bitwise(self):
+        start = dt(2016, 2, 1)
+        end = dt(2016, 2, 10)
+
+        q = (
+            Field("f1").eq("val1")
+            &
+            Field("f2").between(start, end)
+            ^
+            Field("f3").eq("val3")
+        )
+
+        self.assertEqual(
+            str(q),
+            'f1=val1^f2BETWEENjavascript:gs.dateGenerate("2016-02-01 00:00:00")'
+            '@javascript:gs.dateGenerate("2016-02-10 00:00:00")^NQf3=val3',
+        )

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -217,6 +217,27 @@ class TestQueryBuilder(unittest.TestCase):
         )
         self.assertEqual(str(q4), "test>2016-02-01 02:00:00")
 
+    def test_query_cond_greater_than_or_equal(self):
+        # Make sure type checking works
+        q1 = pysnow.QueryBuilder().field("test")
+        self.assertRaises(QueryTypeError, q1.greater_than_or_equal, "a")
+
+        # Make sure a valid operation works
+        q2 = pysnow.QueryBuilder().field("test").greater_than_or_equal(1)
+        self.assertEqual(str(q2), "test>=1")
+
+        # Make sure naive dates are assumed as UTC
+        q3 = pysnow.QueryBuilder().field("test").greater_than_or_equal(dt(2016, 2, 1))
+        self.assertEqual(str(q3), "test>=2016-02-01 00:00:00")
+
+        # Make sure tz-aware dates are converted to UTC (UTC+1)
+        q4 = (
+            pysnow.QueryBuilder()
+            .field("test")
+            .greater_than_or_equal(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
+        )
+        self.assertEqual(str(q4), "test>=2016-02-01 02:00:00")
+
     def test_query_cond_less_than(self):
         # Make sure type checking works
         q1 = pysnow.QueryBuilder().field("test")
@@ -237,6 +258,27 @@ class TestQueryBuilder(unittest.TestCase):
             .less_than(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
         )
         self.assertEqual(str(q3), "test<2016-02-01 02:00:00")
+
+    def test_query_cond_less_than_or_equal(self):
+        # Make sure type checking works
+        q1 = pysnow.QueryBuilder().field("test")
+        self.assertRaises(QueryTypeError, q1.less_than_or_equal, "a")
+
+        # Make sure a valid operation works
+        q2 = pysnow.QueryBuilder().field("test").less_than_or_equal(1)
+        self.assertEqual(str(q2), "test<=1")
+
+        # Make sure naive dates are assumed as UTC
+        q3 = pysnow.QueryBuilder().field("test").less_than_or_equal(dt(2016, 2, 1))
+        self.assertEqual(str(q3), "test<=2016-02-01 00:00:00")
+
+        # Make sure tz-aware dates are converted to UTC (UTC+1)
+        q3 = (
+            pysnow.QueryBuilder()
+            .field("test")
+            .less_than_or_equal(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
+        )
+        self.assertEqual(str(q3), "test<=2016-02-01 02:00:00")
 
     def test_complex_query(self):
         start = dt(2016, 2, 1)


### PR DESCRIPTION
I really like the pypika query builder, so implemented a similar method.

Allows things like:
```
incident = Table('incident')
criterion_list = [
    Field('foo').eq('bar'), 
    incident.bar == 'foo'
]
query = str(reduce(operator.and_, criterion_list))
print(query)

>>> 'foo=bar^bar=foo'

print(str(Field('foo').eq('bar') | incident.bar == 'foo'))

>>> 'foo=bar^ORbar=foo'
```