### PR TITLE
Docstring modified for not_contains

### DIFF
--- a/pysnow/query_builder.py
+++ b/pysnow/query_builder.py
@@ -70,7 +70,7 @@ class QueryBuilder(object):
         return self._add_condition("LIKE", contains, types=[str])
 
     def not_contains(self, not_contains):
-        """Adds new `NOTLIKE` condition
+        """Adds new `NOT LIKE` condition
 
         :param not_contains: Match field not containing the provided value
         """


### PR DESCRIPTION
#162 
As per ServiceNOW documentation and feature provided in not_contains method of pysnow, the correct reference is **NOT LIKE**
@alex-way If the Docstring of the method was your concern I have modified it.
@rbw please approve if appropriate
