### PR TITLE
Allow passing string-type target to Resource.update

### DIFF
--- a/pysnow/request.py
+++ b/pysnow/request.py
@@ -138,11 +138,11 @@ class SnowRequest(object):
         if isinstance(query, str):
             sys_id = query
         else:
-            record = self.get(query=query, fields=["sys_id"]).one()
+            record = self.get(query=query).one()
             sys_id = record["sys_id"]
 
         self._url = self._get_custom_endpoint(sys_id)
-        return self._get_response("PUT", data=json.dumps(payload))
+        return self._get_response("PATCH", data=json.dumps(payload))
 
     def delete(self, query):
         """Deletes a record

--- a/pysnow/request.py
+++ b/pysnow/request.py
@@ -135,9 +135,13 @@ class SnowRequest(object):
         if not isinstance(payload, dict):
             raise InvalidUsage("Update payload must be of type dict")
 
-        record = self.get(query=query).one()
+        if isinstance(query, str):
+            sys_id = query
+        else:
+            record = self.get(query=query, fields=["sys_id"]).one()
+            sys_id = record["sys_id"]
 
-        self._url = self._get_custom_endpoint(record["sys_id"])
+        self._url = self._get_custom_endpoint(sys_id)
         return self._get_response("PUT", data=json.dumps(payload))
 
     def delete(self, query):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -531,6 +531,23 @@ class TestResourceRequest(unittest.TestCase):
         self.assertEquals(response.one(), self.record_response_create)
 
     @httpretty.activate
+    def test_update_sysid(self):
+        """:meth:`update` should return a dictionary of the updated record"""
+
+        sys_id = self.record_response_get_one[0]["sys_id"]
+
+        httpretty.register_uri(
+            httpretty.PATCH,
+            self.mock_url_builder_sys_id,
+            body=get_serialized_result(self.record_response_update),
+            status=200,
+            content_type="application/json",
+        )
+
+        updated = self.resource.update(sys_id, self.record_response_update)
+        self.assertEquals(self.record_response_update["attr1"], updated["attr1"])
+
+    @httpretty.activate
     def test_update(self):
         """:meth:`update` should return a dictionary of the updated record"""
 
@@ -543,7 +560,7 @@ class TestResourceRequest(unittest.TestCase):
         )
 
         httpretty.register_uri(
-            httpretty.PUT,
+            httpretty.PATCH,
             self.mock_url_builder_sys_id,
             body=get_serialized_result(self.record_response_update),
             status=200,
@@ -772,7 +789,7 @@ class TestResourceRequest(unittest.TestCase):
         )
 
         httpretty.register_uri(
-            httpretty.PUT,
+            httpretty.PATCH,
             self.mock_url_builder_sys_id,
             body=get_serialized_result(self.record_response_update),
             status=200,


### PR DESCRIPTION
Adds support for passing target as string:
```python
updated = resource.update("1c741bd70b2322007518478d83673af3", {"short_description": "test"})
print(updated["short_description"])
```

Selection using a dict-type query or the `QueryBuilder` still works:
```python
updated = resource.update({"number": "INC012345"}, {"short_description": "test"})
print(updated["short_description"])
```

This also changes the `Resource.update()` to use the *PATCH* method instead of *PUT*, as some ServiceNow APIs don't support *PUT*. These methods behave the same in ServiceNow nowadays, i.e. this should be a non-breaking change.
