### PR TITLE
bump pytz to 2021.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Pygments==2.4.2
 pyparsing==2.4.4
 python-coveralls==2.9.3
 python-magic==0.4.15
-pytz==2019.3
+pytz==2021.1
 PyYAML==5.1.2
 readme-renderer==24.0
 requests==2.22.0


### PR DESCRIPTION
I'd like to use pysnow, but this older pinned version of pytz is conflicting with other Python libraries.