### PR TITLE
Bump pytz dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python-magic = "^0.4.15"
 requests-oauthlib = "^1.3.0"
 six = "^1.13.0"
 ijson = "^2.5.1"
-pytz = "^2019.3"
+pytz = ">=2019.3"
 
 [tool.poetry.dev-dependencies]
 twine = "^1.13"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Pygments==2.4.2
 pyparsing==2.4.4
 python-coveralls==2.9.3
 python-magic==0.4.15
-pytz==2019.3
+pytz==2022.1
 PyYAML==5.4
 readme-renderer==24.0
 requests==2.22.0


### PR DESCRIPTION
The pyproject.toml file specifies "^2019.3" as the version, but pytz does not use semantic versioning. "^1.2.3" allows versions ">=1.2.3 <2.0.0", so for pytz that means ">=2019.3 <2020".

Instead of pinning to releases from a specific year, specify that version as a minimum version instead.