### PR TITLE
bump up pytz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python-magic = "^0.4.15"
 requests-oauthlib = "^1.3.0"
 six = "^1.13.0"
 ijson = "^2.5.1"
-pytz = "^2019.3"
+pytz = ">=2019.3"
 
 [tool.poetry.dev-dependencies]
 twine = "^1.13"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Pygments==2.4.2
 pyparsing==2.4.4
 python-coveralls==2.9.3
 python-magic==0.4.15
-pytz==2019.3
+pytz>=2019.3
 PyYAML==5.4
 readme-renderer==24.0
 requests==2.22.0


### PR DESCRIPTION
Bumping the pytz requirements after seeing that they are mostly used for offsetting time and providing the UTC offset.

Run test_criterion and test_query_builder and returned no errors. I assume they are valid tests. I do not have currently a ServiceNow instance to test, but will try to procure one and adjust as needed.