### PR TITLE
Move not `(host or instance)` check before `(host and instance)` check

### DIFF
--- a/pysnow/client.py
+++ b/pysnow/client.py
@@ -44,6 +44,9 @@ class Client(object):
         session=None,
     ):
 
+        if not (host or instance):
+            raise InvalidUsage("You must supply either 'instance' or 'host'")
+
         if (host and instance) is not None:
             raise InvalidUsage(
                 "Arguments 'instance' and 'host' are mutually exclusive, you cannot use both."
@@ -64,9 +67,6 @@ class Client(object):
             self.raise_on_empty = raise_on_empty
         else:
             raise InvalidUsage("Argument 'raise_on_empty' must be of type bool")
-
-        if not (host or instance):
-            raise InvalidUsage("You must supply either 'instance' or 'host'")
 
         if not isinstance(self, pysnow.OAuthClient):
             if not (user and password) and not session:


### PR DESCRIPTION
When `host` is an empty string while `instance` is not specified, `(host and instance) is not None` will return `True` because `(host and instance)` will evaluate to `''`. In this case the error message returned will be inappropriate and confusing because the caller didn't specify `host`.