### PR TITLE
use latest ijson (at least 3.3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ oauthlib = "^3.1.0"
 python-magic = "^0.4.15"
 requests-oauthlib = "^1.3.0"
 six = "^1.13.0"
-ijson = "^2.5.1"
+ijson = ">=2.5.1"
 pytz = "^2019.3"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coverage==4.5.4
 docutils==0.15.2
 httpretty==0.9.7
 idna==2.8
-ijson==2.5.1
+ijson>=2.5.1
 imagesize==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
I was unable to get the library installed. The reason is related to the use of `ijson` in the fixed version of 2.5.1.
This change uses the latest available version of it. 

Following the build error for reference: 

```bash
Building wheels for collected packages: ijson
  Building wheel for ijson (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for ijson (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [26 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.linux-x86_64-cpython-313/ijson
      copying ijson/__init__.py -> build/lib.linux-x86_64-cpython-313/ijson
      copying ijson/common.py -> build/lib.linux-x86_64-cpython-313/ijson
      copying ijson/compat.py -> build/lib.linux-x86_64-cpython-313/ijson
      copying ijson/utils.py -> build/lib.linux-x86_64-cpython-313/ijson
      copying ijson/version.py -> build/lib.linux-x86_64-cpython-313/ijson
      creating build/lib.linux-x86_64-cpython-313/ijson/backends
      copying ijson/backends/__init__.py -> build/lib.linux-x86_64-cpython-313/ijson/backends
      copying ijson/backends/python.py -> build/lib.linux-x86_64-cpython-313/ijson/backends
      copying ijson/backends/yajl.py -> build/lib.linux-x86_64-cpython-313/ijson/backends
      copying ijson/backends/yajl2.py -> build/lib.linux-x86_64-cpython-313/ijson/backends
      copying ijson/backends/yajl2_c.py -> build/lib.linux-x86_64-cpython-313/ijson/backends
      copying ijson/backends/yajl2_cffi.py -> build/lib.linux-x86_64-cpython-313/ijson/backends
      running build_ext
      building 'ijson.backends._yajl2' extension
      creating build/temp.linux-x86_64-cpython-313/ijson/backends
      gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -fPIC -I/home/user/snow/.venv/include -I/usr/include/python3.13 -c ijson/backends/_yajl2.c -o build/temp.linux-x86_64-cpython-313/ijson/backends/_yajl2.o
      ijson/backends/_yajl2.c: In function ‘parsegen_iternext’:
      ijson/backends/_yajl2.c:525:21: error: implicit declaration of function ‘PyUnicode_GET_SIZE’; did you mean ‘PyDict_GET_SIZE’? [-Wimplicit-function-declaration]
        525 |                 if( PyUnicode_GET_SIZE(last_path) > 0 ) {
            |                     ^~~~~~~~~~~~~~~~~~
            |                     PyDict_GET_SIZE
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for ijson
Failed to build ijson
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (ijson)
```